### PR TITLE
fix(filters): show all TMDB genres in genre filter

### DIFF
--- a/tv/src/main/java/ca/devmesh/seerrtv/data/SeerrApiService.kt
+++ b/tv/src/main/java/ca/devmesh/seerrtv/data/SeerrApiService.kt
@@ -374,7 +374,7 @@ class SeerrApiService @Inject constructor(
     data class GenreResponse(
         val id: Int,
         val name: String,
-        val backdrops: List<String>
+        val backdrops: List<String> = emptyList()
     )
 
     /**
@@ -2533,6 +2533,77 @@ class SeerrApiService @Inject constructor(
             totalResults = allGenres.size,
             hasMorePages = hasMorePages
         ))
+    }
+
+    /**
+     * Get the FULL list of movie genres from TMDB (via Jellyseerr/Overseerr `genres/movie` endpoint).
+     * Unlike [getMovieGenres] which uses the curated `discover/genreslider/movie` endpoint
+     * (used for the home-screen carousel and limited to genres that have backdrop art),
+     * this returns every TMDB movie genre (Action, Adventure, Animation, Comedy, Crime,
+     * Documentary, Drama, Family, Fantasy, History, Horror, Music, Mystery, Romance,
+     * Science Fiction, TV Movie, Thriller, War, Western).
+     * Used by the filters drawer so the user can filter by ANY genre.
+     */
+    suspend fun getAllMovieGenres(context: Context): ApiResult<List<GenreResponse>> {
+        val locale = SharedPreferencesUtil.getDiscoveryLanguage(context)
+        val apiEndpoint = "genres/movie"
+        val localizedEndpoint = if (locale != "en") "$apiEndpoint?language=$locale" else apiEndpoint
+
+        return try {
+            when (val httpResult = executeApiCall<HttpResponse>(localizedEndpoint)) {
+                is ApiResult.Success -> {
+                    val responseBody = httpResult.data.bodyAsText()
+                    try {
+                        val genresList = json.decodeFromString<List<GenreResponse>>(responseBody)
+                        if (BuildConfig.DEBUG) {
+                            Log.d("SeerrApiService", "Loaded ${genresList.size} movie genres from genres/movie")
+                        }
+                        ApiResult.Success(genresList)
+                    } catch (e: kotlinx.serialization.SerializationException) {
+                        Log.e("SeerrApiService", "Error parsing movie genres array: ${e.message}")
+                        ApiResult.Error(e)
+                    }
+                }
+                is ApiResult.Error -> ApiResult.Error(httpResult.exception, httpResult.statusCode)
+                else -> ApiResult.Loading()
+            }
+        } catch (e: Exception) {
+            Log.e("SeerrApiService", "Error fetching all movie genres: ${e.message}")
+            ApiResult.Error(e)
+        }
+    }
+
+    /**
+     * Get the FULL list of TV genres from TMDB (via Jellyseerr/Overseerr `genres/tv` endpoint).
+     * See [getAllMovieGenres] for the rationale.
+     */
+    suspend fun getAllTVGenres(context: Context): ApiResult<List<GenreResponse>> {
+        val locale = SharedPreferencesUtil.getDiscoveryLanguage(context)
+        val apiEndpoint = "genres/tv"
+        val localizedEndpoint = if (locale != "en") "$apiEndpoint?language=$locale" else apiEndpoint
+
+        return try {
+            when (val httpResult = executeApiCall<HttpResponse>(localizedEndpoint)) {
+                is ApiResult.Success -> {
+                    val responseBody = httpResult.data.bodyAsText()
+                    try {
+                        val genresList = json.decodeFromString<List<GenreResponse>>(responseBody)
+                        if (BuildConfig.DEBUG) {
+                            Log.d("SeerrApiService", "Loaded ${genresList.size} TV genres from genres/tv")
+                        }
+                        ApiResult.Success(genresList)
+                    } catch (e: kotlinx.serialization.SerializationException) {
+                        Log.e("SeerrApiService", "Error parsing TV genres array: ${e.message}")
+                        ApiResult.Error(e)
+                    }
+                }
+                is ApiResult.Error -> ApiResult.Error(httpResult.exception, httpResult.statusCode)
+                else -> ApiResult.Loading()
+            }
+        } catch (e: Exception) {
+            Log.e("SeerrApiService", "Error fetching all TV genres: ${e.message}")
+            ApiResult.Error(e)
+        }
     }
 
     /**

--- a/tv/src/main/java/ca/devmesh/seerrtv/viewmodel/MediaDiscoveryViewModel.kt
+++ b/tv/src/main/java/ca/devmesh/seerrtv/viewmodel/MediaDiscoveryViewModel.kt
@@ -924,14 +924,17 @@ class MediaDiscoveryViewModel @Inject constructor(
     
     fun loadGenres(mediaType: MediaType) {
         viewModelScope.launch {
+            // Use the full TMDB genres list (genres/movie or genres/tv) so the user
+            // can filter by every genre — not the curated genreslider list which is
+            // limited to genres that have backdrop art and is paginated to 8 per page.
             val result = if (mediaType == MediaType.MOVIE) {
-                apiService.getMovieGenres(getApplication())
+                apiService.getAllMovieGenres(getApplication())
             } else {
-                apiService.getTVGenres(getApplication())
+                apiService.getAllTVGenres(getApplication())
             }
-            
+
             when (result) {
-                is ApiResult.Success -> _availableGenres.value = result.data
+                is ApiResult.Success -> _availableGenres.value = result.data.sortedBy { it.name }
                 is ApiResult.Error -> Log.e("MediaDiscoveryViewModel", "Failed to load genres", result.exception)
                 else -> {}
             }


### PR DESCRIPTION
Did by claude, i have no knowledge about how he did but it works great 

## What

The genre filter in the Movies / Series filters drawer now shows every TMDB genre, alphabetically sorted, instead of a small curated subset.

## Why

`MediaDiscoveryViewModel.loadGenres()` was calling `SeerrApiService.getMovieGenres()` / `getTVGenres()`, which hit the curated `discover/genreslider/{movie,tv}` endpoint. That endpoint:

1. Only exposes genres that have backdrop art (intended for the home-screen carousel), so genres like **Thriller**, **Western**, **TV Movie**, etc. are absent.
2. Is paginated to 8 per page client-side, and the filters drawer only ever loads page 1.

The full TMDB genre lists are exposed by Jellyseerr / Overseerr as `genres/movie` and `genres/tv`. This PR uses those for the filter UI.

## How

- `GenreResponse.backdrops` becomes optional (`= emptyList()`) so the same model can deserialize both endpoints.
- New `SeerrApiService.getAllMovieGenres()` / `getAllTVGenres()` calling `genres/{movie,tv}`.
- `MediaDiscoveryViewModel.loadGenres()` switched to these new methods and sorts the result by `name`.

The home-screen `MOVIE_GENRES` / `SERIES_GENRES` category carousel still uses the genreslider endpoint, so its backdrop visuals are unchanged.

## Tested

Built `assembleDirectRelease` and sideloaded on an Android TV device against a Jellyseerr server. The filter drawer now shows all 19 movie / 16 TV TMDB genres alphabetically (Thriller, Western, TV Movie, etc. all present). Home-screen genre carousel unchanged.